### PR TITLE
config: add config to enable/disable 'Nether Man' and 'Nether Dragon'

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -1,12 +1,26 @@
 local modname = minetest.get_current_modname()
 local modpath = minetest.get_modpath(modname)
 
--- Nether Man # 129 code lines
+nethermobs                   = {}
+nethermobs.NETHERMAN_ENABLED = true
+nethermobs.DRAGON_ENABLED    = true
 
-dofile(modpath.."/netherman.lua")
+-- Override default settings with values from the .conf file, if any are present.
+nethermobs.NETHERMAN_ENABLED       = minetest.settings:get_bool("nethermobs.netherman_enabled", nethermobs.NETHERMAN_ENABLED)
+nethermobs.DRAGON_ENABLED          = minetest.settings:get_bool("nethermobs.dragon_enabled", nethermobs.DRAGON_ENABLED)
 
--- Nether Dragon # 657 code lines
+minetest.log("action", "[MOD] Nethermobs loaded")
+minetest.log("info", "[MOD] Nethermobs: nethermobs.NETHERMAN_ENABLED: "..tostring(nethermobs.NETHERMAN_ENABLED))
+minetest.log("info", "[MOD] Nethermobs: nethermobs.DRAGON_ENABLED: "..tostring(nethermobs.DRAGON_ENABLED))
 
-dofile(modpath.."/dragon.lua")
+if nethermobs.NETHERMAN_ENABLED then
+        -- Nether Man # 129 code lines
+        dofile(modpath.."/netherman.lua")
+end
+
+if nethermobs.DRAGON_ENABLED then
+        -- Nether Dragon # 657 code lines
+        dofile(modpath.."/dragon.lua")
+end
 
 -- please read README.md


### PR DESCRIPTION

Add config options to selectively enable or disable 'Nether Man' and 'Nether Dragon'. This defaults to enabled, so the behavior does not change when the new config values are not present.